### PR TITLE
allow pagination-id to be retrieved from $scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repo contains only the release version of the dirPagination module from my
 [angularUtils](https://github.com/michaelbromley/angularUtils/tree/master/src/directives/pagination) repo. The sole purpose of this repo is to allow for convenient 
 dependency management via Bower.
 
+There is a demo of this application available on (Plunker)[http://run.plnkr.co/plunks/ksqjJajB2hGovTvDCibS/]
+
 ## Documentation
 
 All documentation is also located in the [angularUtils project](https://github.com/michaelbromley/angularUtils/tree/master/src/directives/pagination).


### PR DESCRIPTION
Hi!

First up - thanks for making this angular code available! I've been using it in a couple of projects at work.

One modification - with the way the itemsPerPage filter is set up at the moment you're forced to use a completely static pagination id, even though the pagination-id attribute that is passed to the dirPaginate element and the dirPaginate controls is expanded as an angular expression.

I've made a slight tweak that allows for itemsPerPage to also be passed in as an attribute, and if this is case create an itemsPerPage filter in the link method if none is provided. This is useful if I'm constructing a bunch of dirPaginated tables in an ng-repeat loop and I need a dynamically generated paginationId.

There's a link to plunker in the README of an example of this.

Let me know if there's anything you need.
