### PR TITLE
Add CommonJS support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./dirPagination');
+module.exports = 'angularUtils.directives.dirPagination';

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "angular-utils-pagination",
+  "version": "0.7.0",
+  "description": "Magical automatic pagination for anything in AngularJS",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/michaelbromley/angularUtils.git"
+  },
+  "keywords": [
+    "angularjs",
+    "pagination",
+    "directive",
+    "paging",
+    "angular"
+  ],
+  "author": "Michael Bromley <michael@michaelbromley.co.uk>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/michaelbromley/angularUtils/issues"
+  },
+  "homepage": "https://github.com/michaelbromley/angularUtils/tree/master/src/directives/pagination"
+}


### PR DESCRIPTION
Hi Michael,

this pr makes it possible for the module to work with tools like Browserify; I've followed the same pattern used by the Angular team to make the core Angular modules CommonJS-compliant.

It would be great if you could also publish the package to npmjs, it shouldn't be hard according to what's described here https://docs.npmjs.com/getting-started/publishing-npm-packages and could help to make your directive even more popular by reaching npm users :)

Thank you a lot,
Francesco