### PR TITLE
(chore): Add packaging for Meteor.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,8 @@ $RECYCLE.BIN/
 .LSOverride
 
 # Icon must ends with two \r.
-Icon
+Icon
+
 
 # Thumbnails
 ._*
@@ -34,3 +35,6 @@ Icon
 # Files that might appear on external disk
 .Spotlight-V100
 .Trashes
+
+#IDE
+.idea

--- a/.versions
+++ b/.versions
@@ -1,0 +1,4 @@
+angular:angular@1.2.24
+angularutils:pagination@0.7.0
+meteor@1.1.6
+underscore@1.0.3

--- a/package.js
+++ b/package.js
@@ -1,0 +1,14 @@
+Package.describe({
+  name: 'angularutils:pagination',
+  summary: 'Magical automatic pagination for anything in AngularJS',
+  version: '0.7.0',
+  git: 'https://github.com/Urigo/angularUtils-pagination'
+});
+
+Package.onUse(function(api) {
+  api.versionsFrom(['METEOR@0.9.0', 'METEOR@1.0']);
+
+  api.use('angular:angular@1.2.24', 'client');
+
+  api.addFiles('dirPagination.js', 'client');
+});


### PR DESCRIPTION
Hi @michaelbromley

I'm a package maintainer for [Meteor.js](https://www.meteor.com/), a popular full-stack JavaScript framework.

I'm also the creator of [angular-meteor](http://angularjs.meteor.com/), a library that let's you work with AngularJS on top of Meteor.

I use angularUtils-pagination on our [tutorial](http://angularjs.meteor.com/tutorial/step_12).
Until now I've been publishing your library to Meteor myself but I think it is better you add an official Meteor release as a lot of users use that.

This PR will allow you to directly publish updated versions of angularUtils-pagination as they become available. 
All you have to do is create an account at https://meteor.com/ (click SIGN IN, then Create account). After you've done that, please let me know the name of the account, and I'll add you as the owner of the angularUtils organization there (or you can create it under your username or a different organization, whatever you want).

I've already published the current version of the [package on Atmosphere](https://atmospherejs.com/angularutils/pagination) (Meteor's package directory).

If you use Grunt or Gulp as part of your release, there are prepared tasks for publishing to Meteor here:
https://github.com/MeteorPackaging/grunt-gulp-meteor

Thanks & best regards,
Uri