### PR TITLE
Fix dependencies field in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,9 +10,9 @@
   "moduleType": [
     "globals"
   ],
-  "dependencies": [
-	"angular": ">=1.1.4"
-  ],
+  "dependencies": {
+    "angular": ">=1.1.4"
+  },
   "keywords": [
     "angularjs",
     "pagination",


### PR DESCRIPTION
The malformed json in the dependencies field of bower.json causes bower
to fail.