### PR TITLE
Use index.js as npm package entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-utils-pagination",
   "version": "0.9.2",
   "description": "Magical automatic pagination for anything in AngularJS",
-  "main": "dirPagination.js",
+  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
`index.js` was presumably added to support CommonJS syntax; however, `package.json` was not updated to point at this file. Thus, the name of the module was not being exported correctly if one were to `require()` the package in their `angular.module` list.

This PR fixes that.