### PR TITLE
Allow ellipsis "pages" to be used as buttons

### DIFF
--- a/dirPagination.js
+++ b/dirPagination.js
@@ -326,10 +326,27 @@
                 }
             });
 
-            scope.setCurrent = function(num) {
-                if (paginationService.isRegistered(paginationId) && isValidPageNumber(num)) {
-                    num = parseInt(num, 10);
-                    paginationService.setCurrentPage(paginationId, num);
+            scope.setCurrent = function (num, index) {
+                if (paginationService.isRegistered(paginationId)) {
+                    if (num === '...') {
+                        /* Ellipsis entry */
+                        // setCurrent is being called on an ellipsis, so assume that it's being used as a button and we need to work out where it should go.
+                        if (index === 1) { // Opening Ellipsis
+                            // Get the first page after the opening ellipsis to find which page comes before it. For example, given the page set 1 ... 15, 16, 17, selecting the opening ellipsis,
+                            // would result in page 14 (scope.pages[index + 1] = 15 - 1 = 14) becoming selected.
+                            num = scope.pages[index + 1] - 1; // Verbose for clarity.
+                        }
+                        else { // Closing Ellipsis
+                            // Get the last page before the closing ellipsis to find which page should come next.
+                            num = scope.pages[index - 1] + 1;
+                        }
+                    }
+
+                    if (isValidPageNumber(num)) {
+                        num = parseInt(num, 10);
+
+                        paginationService.setCurrentPage(paginationId, num);
+                    }
                 }
             };
 

--- a/dirPagination.tpl.html
+++ b/dirPagination.tpl.html
@@ -6,7 +6,7 @@
         <a href="" ng-click="setCurrent(pagination.current - 1)">&lsaquo;</a>
     </li>
     <li ng-repeat="pageNumber in pages track by tracker(pageNumber, $index)" ng-class="{ active : pagination.current == pageNumber, disabled : pageNumber == '...' }">
-        <a href="" ng-click="setCurrent(pageNumber)">{{ pageNumber }}</a>
+        <a href="" ng-click="setCurrent(pageNumber, $index)">{{ pageNumber }}</a>
     </li>
 
     <li ng-if="directionLinks" ng-class="{ disabled : pagination.current == pagination.last }">


### PR DESCRIPTION
Allow ellipsis "pages" to be used as buttons by logically finding the previous or next page required for the current page set.

I found this useful for a project I was working on and thought others might also. Please feel free to change my code and comments to your preferred style, or if you'd like to discuss anything just let me know!
